### PR TITLE
Access Delegation Workflow using Rsvp

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -8,6 +8,7 @@ const Hoek = require('hoek');
 const Hawk = require('hawk');
 const Ticket = require('./ticket');
 const Server = require('./server');
+const Scope = require('./scope');
 
 
 // Declare internals
@@ -189,14 +190,14 @@ exports.rsvp = function (req, payload, options, callback) {
                 }
 
                 if (!grant ||
-                    grant.app !== ticket.app ||
+                    (grant.app !== ticket.app && (!envelope.delegate || grant.app !== envelope.delegate.dlg)) ||
                     !grant.exp ||
                     grant.exp <= now) {
 
                     return callback(Boom.forbidden('Invalid grant'));
                 }
 
-                options.loadAppFunc(grant.app, (err, app) => {
+                options.loadAppFunc(ticket.app, (err, app) => {
 
                     if (err) {
                         return callback(err);
@@ -206,10 +207,18 @@ exports.rsvp = function (req, payload, options, callback) {
                         return callback(Boom.forbidden('Invalid application'));
                     }
 
-                    let ticketOptions = options.ticket || {};
+                    const ticketOptions = Hoek.shallow(options.ticket || {});
+
                     if (ext) {
-                        ticketOptions = Hoek.shallow(ticketOptions);
                         ticketOptions.ext = ext;
+                    }
+
+                    if (envelope.delegate) {
+                        ticketOptions.dlg = envelope.delegate.dlg;
+
+                        if (envelope.delegate.scope) {
+                            ticketOptions.scope = envelope.delegate.scope;
+                        }
                     }
 
                     Ticket.issue(app, grant, options.encryptionPassword, ticketOptions, callback);
@@ -217,4 +226,135 @@ exports.rsvp = function (req, payload, options, callback) {
             });
         });
     });
+};
+
+// Request a ticket delegation rsvp using the authenticating ticket
+
+internals.schema.delegate = Joi.object({
+    delegateTo: Joi.string().required(),
+    scope: Joi.array().items(Joi.string())
+});
+
+exports.delegate = function (req, payload, options, callback) {
+
+    payload = payload || {};
+
+    const validate = () => {
+
+        let error = Joi.validate(payload, internals.schema.delegate).error;
+        if (error) {
+            return callback(Boom.badRequest(error.message));
+        }
+
+        Server.authenticate(req, options.encryptionPassword, options, (err, ticket, artifacts) => {
+
+            if (err) {
+                return callback(err);
+            }
+
+            if (ticket.dlg) {
+                return fail(Boom.badRequest('Cannot re-delegate'));
+            }
+
+            if (ticket.delegate === false) {          // Defaults to true
+                return fail(Boom.forbidden('Ticket does not allow delegation'));
+            }
+
+            if (ticket.scope) {
+                error = Scope.validate(ticket.scope);
+                if (error) {
+                    return fail(error);
+                }
+            }
+
+            if (payload.scope) {
+                error = Scope.validate(payload.scope);
+                if (error) {
+                    return fail(error);
+                }
+
+                if (!Scope.isSubset(ticket.scope, payload.scope)) {
+                    return fail(Boom.forbidden('New scope is not a subset of the parent ticket scope'));
+                }
+            }
+
+            // Load app
+
+            options.loadAppFunc(ticket.app, (err, app) => {
+
+                if (err) {
+                    return callback(err);
+                }
+
+                if (!app) {
+                    return callback(Hawk.utils.unauthorized('Invalid application'));
+                }
+
+                if (!app.delegate) {
+                    return callback(Boom.forbidden('Application has no delegation rights'));
+                }
+
+                // Load delegated app
+
+                options.loadAppFunc(payload.delegateTo, (err, delegatedApp) => {
+
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    if (!delegatedApp) {
+                        return callback(Hawk.utils.unauthorized('Invalid application'));
+                    }
+
+                    // Application ticket
+
+                    if (!ticket.grant) {
+                        return delegate(ticket, delegatedApp);
+                    }
+
+                    // User ticket
+
+                    options.loadGrantFunc(ticket.grant, (err, grant, ext) => {
+
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        if (!grant ||
+                            (grant.app !== ticket.app && grant.app !== ticket.dlg) ||
+                            grant.user !== ticket.user ||
+                            !grant.exp ||
+                            grant.exp <= Hawk.utils.now()) {
+
+                            return callback(Hawk.utils.unauthorized('Invalid grant'));
+                        }
+
+                        return delegate(ticket, delegatedApp, grant);
+                    });
+                });
+            });
+        });
+    };
+
+    const delegate = (ticket, delegatedApp, grant) => {
+
+        const ticketOptions = Hoek.shallow(options.ticket || {});
+
+        ticketOptions.dlg = ticket.app;
+
+        if (payload.scope) {
+            ticketOptions.scope = payload.scope;
+        }
+
+        Ticket.rsvp(delegatedApp, grant, options.encryptionPassword, ticketOptions, (err, rsvp) => {
+
+            if (err) {
+                return callback(err);
+            }
+
+            callback(null, { rsvp: rsvp });
+        });
+    };
+
+    validate();
 };

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -183,18 +183,34 @@ exports.rsvp = function (req, payload, options, callback) {
                 return callback(Boom.forbidden('Expired rsvp'));
             }
 
-            options.loadGrantFunc(envelope.grant, (err, grant, ext) => {
+            const validateGrant = (done) => {
+
+                if (!envelope.grant && envelope.dlg) {
+                    return done();
+                }
+
+                options.loadGrantFunc(envelope.grant, (err, grant, ext) => {
+
+                    if (err) {
+                        return done(err);
+                    }
+
+                    if (!grant ||
+                        (grant.app !== ticket.app && grant.app !== envelope.dlg) ||
+                        !grant.exp ||
+                        grant.exp <= now) {
+
+                        return done(Boom.forbidden('Invalid grant'));
+                    }
+
+                    return done(null, grant, ext);
+                });
+            };
+
+            validateGrant((err, grant, ext) => {
 
                 if (err) {
                     return callback(err);
-                }
-
-                if (!grant ||
-                    (grant.app !== ticket.app && (!envelope.delegate || grant.app !== envelope.delegate.dlg)) ||
-                    !grant.exp ||
-                    grant.exp <= now) {
-
-                    return callback(Boom.forbidden('Invalid grant'));
                 }
 
                 options.loadAppFunc(ticket.app, (err, app) => {
@@ -213,11 +229,11 @@ exports.rsvp = function (req, payload, options, callback) {
                         ticketOptions.ext = ext;
                     }
 
-                    if (envelope.delegate) {
-                        ticketOptions.dlg = envelope.delegate.dlg;
+                    if (envelope.dlg) {
+                        ticketOptions.dlg = envelope.dlg;
 
-                        if (envelope.delegate.scope) {
-                            ticketOptions.scope = envelope.delegate.scope;
+                        if (envelope.scope) {
+                            ticketOptions.scope = envelope.scope;
                         }
                     }
 
@@ -250,10 +266,6 @@ exports.delegate = function (req, payload, options, callback) {
 
             if (err) {
                 return callback(err);
-            }
-
-            if (!ticket.user) {
-                return callback(Hawk.utils.unauthorized('App ticket cannot be delegated'));
             }
 
             if (ticket.dlg) {
@@ -303,45 +315,51 @@ exports.delegate = function (req, payload, options, callback) {
                         return callback(Hawk.utils.unauthorized('Invalid application'));
                     }
 
-                    options.loadGrantFunc(ticket.grant, (err, grant, ext) => {
+                    const validateGrant = (done) => {
+
+                        if (!ticket.grant) {
+                            return done();
+                        }
+
+                        options.loadGrantFunc(ticket.grant, (err, grant, ext) => {
+
+                            if (err) {
+                                return done(err);
+                            }
+
+                            if (!grant ||
+                                grant.app !== ticket.app ||
+                                grant.user !== ticket.user ||
+                                !grant.exp ||
+                                grant.exp <= Hawk.utils.now()) {
+
+                                return done(Hawk.utils.unauthorized('Invalid grant'));
+                            }
+
+                            return done(null, grant, ext);
+                        });
+                    };
+
+                    validateGrant((err, grant, ext) => {
 
                         if (err) {
                             return callback(err);
                         }
 
-                        if (!grant ||
-                            grant.app !== ticket.app ||
-                            grant.user !== ticket.user ||
-                            !grant.exp ||
-                            grant.exp <= Hawk.utils.now()) {
-
-                            return callback(Hawk.utils.unauthorized('Invalid grant'));
-                        }
-
-                        return delegate(ticket, delegatedApp, grant);
+                        return delegate(delegatedApp, app, ticket, grant);
                     });
                 });
             });
         });
     };
 
-    const delegate = (ticket, delegatedApp, grant) => {
+    const delegate = (delegatedApp, delegatingApp, ticket, grant) => {
 
         const ticketOptions = Hoek.shallow(options.ticket || {});
 
-        ticketOptions.dlg = ticket.app;
+        Ticket.delegateRsvp(delegatedApp, delegatingApp, grant, payload.scope, options.encryptionPassword, ticketOptions, (err, rsvp) => {
 
-        if (payload.scope) {
-            ticketOptions.scope = payload.scope;
-        }
-
-        Ticket.rsvp(delegatedApp, grant, options.encryptionPassword, ticketOptions, (err, rsvp) => {
-
-            if (err) {
-                return callback(err);
-            }
-
-            callback(null, { rsvp: rsvp });
+            callback(err, { rsvp: rsvp });
         });
     };
 

--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -252,29 +252,26 @@ exports.delegate = function (req, payload, options, callback) {
                 return callback(err);
             }
 
+            if (!ticket.user) {
+                return callback(Hawk.utils.unauthorized('App ticket cannot be delegated'));
+            }
+
             if (ticket.dlg) {
-                return fail(Boom.badRequest('Cannot re-delegate'));
+                return callback(Boom.badRequest('Cannot re-delegate'));
             }
 
             if (ticket.delegate === false) {          // Defaults to true
-                return fail(Boom.forbidden('Ticket does not allow delegation'));
-            }
-
-            if (ticket.scope) {
-                error = Scope.validate(ticket.scope);
-                if (error) {
-                    return fail(error);
-                }
+                return callback(Boom.forbidden('Ticket does not allow delegation'));
             }
 
             if (payload.scope) {
                 error = Scope.validate(payload.scope);
                 if (error) {
-                    return fail(error);
+                    return callback(error);
                 }
 
                 if (!Scope.isSubset(ticket.scope, payload.scope)) {
-                    return fail(Boom.forbidden('New scope is not a subset of the parent ticket scope'));
+                    return callback(Boom.forbidden('New scope is not a subset of the parent ticket scope'));
                 }
             }
 
@@ -306,14 +303,6 @@ exports.delegate = function (req, payload, options, callback) {
                         return callback(Hawk.utils.unauthorized('Invalid application'));
                     }
 
-                    // Application ticket
-
-                    if (!ticket.grant) {
-                        return delegate(ticket, delegatedApp);
-                    }
-
-                    // User ticket
-
                     options.loadGrantFunc(ticket.grant, (err, grant, ext) => {
 
                         if (err) {
@@ -321,7 +310,7 @@ exports.delegate = function (req, payload, options, callback) {
                         }
 
                         if (!grant ||
-                            (grant.app !== ticket.app && grant.app !== ticket.dlg) ||
+                            grant.app !== ticket.app ||
                             grant.user !== ticket.user ||
                             !grant.exp ||
                             grant.exp <= Hawk.utils.now()) {

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -268,8 +268,6 @@ exports.reissue = function (parentTicket, grant, encryptionPassword, options, ca
 
     const options = {
         ttl: 1 * 60 * 10000,            // Rsvp TTL
-        dlg: '456',                     // The delegating application id
-        scope: ['a'],                   // Subset of grant scope to delegate
         iron: {}                        // Override Iron defaults
     };
 */
@@ -278,11 +276,68 @@ exports.rsvp = function (app, grant, encryptionPassword, options, callback) {
 
     const fail = Hoek.nextTick(callback);
 
+    if (!grant) {
+        return fail(Boom.internal('Invalid grant object'));
+    }
+
+    exports._rsvp(app, grant, {}, encryptionPassword, options, callback);
+};
+
+/*
+    // The delegated application
+
+    const app = {
+        id: '123'                       // Application id
+    };
+
+    // The delegating application
+
+    const dlg = {
+        id: '456'                       // Application id
+    };
+
+    // The grant (optional)
+
+    const grant = {
+        id: 'd832d9283hd9823dh'         // Persistent identifier used to issue additional tickets or revoke access
+    };
+
+    // Subset of grant scope to delegate
+
+    const scope = ['a'];
+
+    const options = {
+        ttl: 1 * 60 * 10000,            // Rsvp TTL
+        iron: {}                        // Override Iron defaults
+    };
+*/
+
+exports.delegateRsvp = function (app, dlg, grant, scope, encryptionPassword, options, callback) {
+
+    const fail = Hoek.nextTick(callback);
+
+    if (!dlg || !dlg.id) {
+        return fail(Boom.internal('Invalid delegating application object'));
+    }
+
+    const envelope = { dlg: dlg.id };
+
+    if (grant && scope) {
+        envelope.scope = scope;
+    }
+
+    exports._rsvp(app, grant, envelope, encryptionPassword, options, callback);
+};
+
+exports._rsvp = function (app, grant, envelope, encryptionPassword, options, callback) {
+
+    const fail = Hoek.nextTick(callback);
+
     if (!app || !app.id) {
         return fail(Boom.internal('Invalid application object'));
     }
 
-    if (!grant || !grant.id) {
+    if (grant && !grant.id) {
         return fail(Boom.internal('Invalid grant object'));
     }
 
@@ -296,25 +351,13 @@ exports.rsvp = function (app, grant, encryptionPassword, options, callback) {
 
     options.ttl = options.ttl || internals.defaults.rsvpTTL;
 
-    // Construct envelope
-
-    const envelope = {
+    Hoek.merge(envelope, {
         app: app.id,
-        exp: Hawk.utils.now() + options.ttl,
-        grant: grant.id
-    };
+        exp: Hawk.utils.now() + options.ttl
+    });
 
-    // Add options for delegation rsvp
-
-    if (options.dlg) {
-
-        const delegateOptions = { dlg: options.dlg };
-
-        if (options.scope) {
-            delegateOptions.scope = options.scope;
-        }
-
-        envelope.delegate = delegateOptions;
+    if (grant) {
+        envelope.grant = grant.id;
     }
 
     // Stringify and encrypt
@@ -329,7 +372,6 @@ exports.rsvp = function (app, grant, encryptionPassword, options, callback) {
         return callback(null, rsvp);
     });
 };
-
 
 /*
     const ticket = {

--- a/lib/ticket.js
+++ b/lib/ticket.js
@@ -47,7 +47,9 @@ internals.defaults = {
                 x: 1
             }
         },
-        iron: {}                        // Override Iron defaults
+        dlg: '456',                     // Delegating application id
+        scope: ['b'],                   // Subset of grant scope to delegate
+        iron: {},                       // Override Iron defaults
         keyBytes: 32,                   // Hawk key length
         hmacAlgorithm: 'sha256'         // Hawk algorithm
     };
@@ -73,7 +75,7 @@ exports.issue = function (app, grant, encryptionPassword, options, callback) {
         return fail(Boom.internal('Invalid options object'));
     }
 
-    const scope = (grant && grant.scope) || app.scope || [];
+    const scope = options.scope || (grant && grant.scope) || app.scope || [];
     const error = Scope.validate(scope);
     if (error) {
         return fail(error);
@@ -107,6 +109,10 @@ exports.issue = function (app, grant, encryptionPassword, options, callback) {
 
     if (options.delegate === false) {           // Defaults to true
         ticket.delegate = false;
+    }
+
+    if (options.dlg) {
+        ticket.dlg = options.dlg;
     }
 
     exports.generate(ticket, encryptionPassword, options, callback);
@@ -262,6 +268,8 @@ exports.reissue = function (parentTicket, grant, encryptionPassword, options, ca
 
     const options = {
         ttl: 1 * 60 * 10000,            // Rsvp TTL
+        dlg: '456',                     // The delegating application id
+        scope: ['a'],                   // Subset of grant scope to delegate
         iron: {}                        // Override Iron defaults
     };
 */
@@ -295,6 +303,19 @@ exports.rsvp = function (app, grant, encryptionPassword, options, callback) {
         exp: Hawk.utils.now() + options.ttl,
         grant: grant.id
     };
+
+    // Add options for delegation rsvp
+
+    if (options.dlg) {
+
+        const delegateOptions = { dlg: options.dlg };
+
+        if (options.scope) {
+            delegateOptions.scope = options.scope;
+        }
+
+        envelope.delegate = delegateOptions;
+    }
 
     // Stringify and encrypt
 

--- a/test/endpoints.js
+++ b/test/endpoints.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Code = require('code');
+const Hoek = require('hoek');
 const Iron = require('iron');
 const Lab = require('lab');
 const Oz = require('../lib');
@@ -1331,6 +1332,60 @@ describe('Endpoints', () => {
             });
         });
 
+        it('fails on invalid rsvp (grant delegating app mismatch)', (done) => {
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, apps[id]);
+                },
+                ticket: {
+                    iron: Iron.defaults
+                }
+            };
+
+            const grant = {
+                id: 'a1b2c3d4e5f6g7h8i9j0',
+                app: appTicket.app,
+                user: 'john',
+                exp: Oz.hawk.utils.now() + 60000
+            };
+
+            const rsvpOptions = {
+                dlg: apps.network.id
+            };
+
+            Oz.ticket.rsvp(apps.social, grant, encryptionPassword, rsvpOptions, (err, rsvp) => {
+
+                expect(err).to.not.exist();
+
+                options.loadGrantFunc = function (id, callback) {
+
+                    grant.app = 'xyz';
+                    callback(null, grant);
+                };
+
+                const payload = { rsvp: rsvp };
+
+                const req = {
+                    method: 'POST',
+                    url: '/oz/rsvp',
+                    headers: {
+                        host: 'example.com',
+                        authorization: Oz.client.header('http://example.com/oz/rsvp', 'POST', appTicket).field
+                    }
+                };
+
+                Oz.endpoints.rsvp(req, payload, options, (err, ticket) => {
+
+                    expect(err).to.exist();
+                    expect(err.message).to.equal('Invalid grant');
+                    done();
+                });
+            });
+        });
+
         it('fails on invalid rsvp (grant missing exp)', (done) => {
 
             const options = {
@@ -1532,6 +1587,885 @@ describe('Endpoints', () => {
                     expect(err.message).to.equal('Invalid application');
                     done();
                 });
+            });
+        });
+    });
+
+    describe('delegate()', () => {
+
+        const grant = {
+            id: 'a1b2c3d4e5f6g7h8i9j0',
+            app: apps.social.id,
+            user: 'john',
+            exp: Oz.hawk.utils.now() + 60000
+        };
+
+        let userTicket = null;
+
+        before((done) => {
+
+            Oz.ticket.rsvp(apps.social, grant, encryptionPassword, {}, (err, rsvp) => {
+
+                expect(err).to.not.exist();
+
+                const options = {
+                    encryptionPassword: encryptionPassword,
+                    loadAppFunc: function (id, callback) {
+
+                        callback(null, apps[id]);
+                    },
+                    loadGrantFunc: function (id, callback) {
+
+                        callback(null, grant);
+                    }
+                };
+
+                const payload = { rsvp: rsvp };
+
+                const req = {
+                    method: 'POST',
+                    url: '/oz/rsvp',
+                    headers: {
+                        host: 'example.com',
+                        authorization: Oz.client.header('http://example.com/oz/rsvp', 'POST', appTicket).field
+                    }
+                };
+
+                Oz.endpoints.rsvp(req, payload, options, (err, ticket) => {
+
+                    expect(err).to.not.exist();
+                    userTicket = ticket;
+                    done();
+                });
+            });
+        });
+
+        it('overrides defaults', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                },
+                ticket: {
+                    ttl: 10 * 60 * 1000,
+                    iron: Iron.defaults
+                },
+                hawk: {}
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (missing payload)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = null;
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (invalid request params)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: null };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                done();
+            });
+        });
+
+        it('fails on invalid authentication', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com'
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                done();
+            });
+        });
+
+        it('fails on expired ticket', (done) => {
+
+            // User ticket
+
+            Oz.ticket.rsvp(apps.social, grant, encryptionPassword, {}, (err, rsvp) => {
+
+                expect(err).to.not.exist();
+
+                const options = {
+                    encryptionPassword: encryptionPassword,
+                    loadAppFunc: function (id, callback) {
+
+                        callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                    },
+                    loadGrantFunc: function (id, callback) {
+
+                        callback(null, grant);
+                    },
+                    ticket: {
+                        ttl: 5
+                    }
+                };
+
+                const payload1 = { rsvp: rsvp };
+
+                const req1 = {
+                    method: 'POST',
+                    url: '/oz/rsvp',
+                    headers: {
+                        host: 'example.com',
+                        authorization: Oz.client.header('http://example.com/oz/rsvp', 'POST', appTicket).field
+                    }
+                };
+
+                Oz.endpoints.rsvp(req1, payload1, options, (err, expiringUserTicket) => {
+
+                    expect(err).to.not.exist();
+
+                    const req2 = {
+                        method: 'POST',
+                        url: '/oz/delegate',
+                        headers: {
+                            host: 'example.com',
+                            authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', expiringUserTicket).field
+                        }
+                    };
+
+                    const payload2 = { delegateTo: apps.network.id };
+
+                    setTimeout(() => {
+
+                        Oz.endpoints.delegate(req2, payload2, options, (err, delegate) => {
+
+                            expect(err).to.exist();
+                            done();
+                        });
+                    }, 10);
+                });
+            });
+        });
+
+        it('fails on invalid delegate (app ticket)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', appTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('App ticket cannot be delegated');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (delegated ticket)', (done) => {
+
+            const req1 = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req1, payload, options, (err, delegate1) => {
+
+                expect(err).to.not.exist();
+
+                // App token for delegated app
+
+                const req2 = {
+                    method: 'POST',
+                    url: '/oz/app',
+                    headers: {
+                        host: 'example.com',
+                        authorization: Oz.client.header('http://example.com/oz/app', 'POST', apps.network).field
+                    }
+                };
+
+                Oz.endpoints.app(req2, null, options, (err, delegatedAppTicket) => {
+
+                    expect(err).to.not.exist();
+
+                    // User token for delegated app
+
+                    const req3 = {
+                        method: 'POST',
+                        url: '/oz/rsvp',
+                        headers: {
+                            host: 'example.com',
+                            authorization: Oz.client.header('http://example.com/oz/rsvp', 'POST', delegatedAppTicket).field
+                        }
+                    };
+
+                    Oz.endpoints.rsvp(req3, delegate1, options, (err, delegatedUserTicket) => {
+
+                        expect(err).to.not.exist();
+
+                        const req4 = {
+                            method: 'POST',
+                            url: '/oz/delegate',
+                            headers: {
+                                host: 'example.com',
+                                authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', delegatedUserTicket).field
+                            }
+                        };
+
+                        payload.delegateTo = 'xyz';
+
+                        Oz.endpoints.delegate(req4, payload, options, (err, delegate2) => {
+
+                            expect(err).to.exist();
+                            expect(err.message).to.equal('Cannot re-delegate');
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
+        it('fails on invalid delegate (delegate disallowed in ticket)', (done) => {
+
+            // User ticket with disabled delegation
+
+            Oz.ticket.rsvp(apps.social, grant, encryptionPassword, {}, (err, rsvp) => {
+
+                expect(err).to.not.exist();
+
+                const options = {
+                    encryptionPassword: encryptionPassword,
+                    loadAppFunc: function (id, callback) {
+
+                        callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                    },
+                    loadGrantFunc: function (id, callback) {
+
+                        callback(null, grant);
+                    },
+                    ticket: {
+                        delegate: false
+                    }
+                };
+
+                const payload1 = { rsvp: rsvp };
+
+                const req1 = {
+                    method: 'POST',
+                    url: '/oz/rsvp',
+                    headers: {
+                        host: 'example.com',
+                        authorization: Oz.client.header('http://example.com/oz/rsvp', 'POST', appTicket).field
+                    }
+                };
+
+                Oz.endpoints.rsvp(req1, payload1, options, (err, ticket) => {
+
+                    expect(err).to.not.exist();
+
+                    const req2 = {
+                        method: 'POST',
+                        url: '/oz/delegate',
+                        headers: {
+                            host: 'example.com',
+                            authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', ticket).field
+                        }
+                    };
+
+                    const payload2 = { delegateTo: apps.network.id };
+
+                    Oz.endpoints.delegate(req2, payload2, options, (err, delegate) => {
+
+                        expect(err).to.exist();
+                        expect(err.message).to.equal('Ticket does not allow delegation');
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('fails on invalid delegate (invalid scope)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = {
+                delegateTo: apps.network.id,
+                scope: ['a','a']
+            };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('scope includes duplicated item');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (missing parent scope)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = {
+                delegateTo: apps.network.id,
+                scope: ['d']
+            };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('New scope is not a subset of the parent ticket scope');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (app load error)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    if (id === apps.social.id) {
+                        callback(new Error('not found'));
+                    }
+                    else {
+                        callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                    }
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('not found');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (invalid app)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    if (id === apps.social.id) {
+                        callback(null, null);
+                    }
+                    else {
+                        callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                    }
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid application');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (missing app delegation rights)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, apps[id]);
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Application has no delegation rights');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (delegated app load error)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    if (id === apps.network.id) {
+                        callback(new Error('not found'));
+                    }
+                    else {
+                        callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                    }
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('not found');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (invalid delegated app)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    if (id === apps.network.id) {
+                        callback(null, null);
+                    }
+                    else {
+                        callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                    }
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid application');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (grant load error)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(new Error('what?'));
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('what?');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (invalid grant)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, null);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid grant');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (grant app mismatch)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    const grantWithDifferentApp = Hoek.shallow(grant);
+                    grantWithDifferentApp.app = 'xyz';
+                    callback(null, grantWithDifferentApp);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid grant');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (grant user mismatch)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    const grantWithDifferentApp = Hoek.shallow(grant);
+                    grantWithDifferentApp.user = 'steve';
+                    callback(null, grantWithDifferentApp);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid grant');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (grant missing exp)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    callback(null, Hoek.merge({ delegate: true }, apps[id]));
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    const grantWithoutExp = Hoek.shallow(grant);
+                    delete grantWithoutExp.exp;
+                    callback(null, grantWithoutExp);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid grant');
+                done();
+            });
+        });
+
+        it('fails on invalid delegate (rsvp error)', (done) => {
+
+            const req = {
+                method: 'POST',
+                url: '/oz/delegate',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', userTicket).field
+                }
+            };
+
+            const options = {
+                encryptionPassword: encryptionPassword,
+                loadAppFunc: function (id, callback) {
+
+                    const invalidApp = Hoek.merge({ delegate: true }, apps[id]);
+                    delete invalidApp.id;
+                    callback(null, invalidApp);
+                },
+                loadGrantFunc: function (id, callback) {
+
+                    callback(null, grant);
+                }
+            };
+
+            const payload = { delegateTo: apps.network.id };
+
+            Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid application object');
+                done();
             });
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -164,6 +164,165 @@ describe('Oz', () => {
             });
         });
     });
+
+    it('runs a full authorization flow using rsvp-based access delegation', (done) => {
+
+        const encryptionPassword = 'a_password_that_is_not_too_short_and_also_not_very_random_but_is_good_enough';
+
+        const apps = {
+            social: {
+                id: 'social',
+                scope: ['a', 'b', 'c'],
+                key: 'werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn',
+                algorithm: 'sha256',
+                delegate: true
+            },
+            network: {
+                id: 'network',
+                scope: ['b', 'x'],
+                key: 'witf745itwn7ey4otnw7eyi4t7syeir7bytise7rbyi',
+                algorithm: 'sha256'
+            }
+        };
+
+        // The app requests an app ticket using Oz.hawk authentication
+
+        let req = {
+            method: 'POST',
+            url: '/oz/app',
+            headers: {
+                host: 'example.com',
+                authorization: Oz.client.header('http://example.com/oz/app', 'POST', apps.social).field
+            }
+        };
+
+        const options = {
+            encryptionPassword: encryptionPassword,
+            loadAppFunc: function (id, callback) {
+
+                callback(null, apps[id]);
+            }
+        };
+
+        Oz.endpoints.app(req, null, options, (err, appTicket) => {
+
+            expect(err).to.not.exist();
+
+            // The app refreshes its own ticket
+
+            req = {
+                method: 'POST',
+                url: '/oz/reissue',
+                headers: {
+                    host: 'example.com',
+                    authorization: Oz.client.header('http://example.com/oz/reissue', 'POST', appTicket).field
+                }
+            };
+
+            Oz.endpoints.reissue(req, {}, options, (err, reAppTicket) => {
+
+                expect(err).to.not.exist();
+
+                // The user is redirected to the server, logs in, and grant app access, resulting in an rsvp
+
+                const grant = {
+                    id: 'a1b2c3d4e5f6g7h8i9j0',
+                    app: reAppTicket.app,
+                    user: 'john',
+                    exp: Oz.hawk.utils.now() + 60000
+                };
+
+                Oz.ticket.rsvp(apps.social, grant, encryptionPassword, {}, (err, rsvp) => {
+
+                    expect(err).to.not.exist();
+
+                    // After granting app access, the user returns to the app with the rsvp
+
+                    options.loadGrantFunc = function (id, callback) {
+
+                        const ext = {
+                            public: 'everybody knows',
+                            private: 'the the dice are loaded'
+                        };
+
+                        callback(null, grant, ext);
+                    };
+
+                    // The app exchanges the rsvp for a ticket
+
+                    let payload = { rsvp: rsvp };
+
+                    req = {
+                        method: 'POST',
+                        url: '/oz/rsvp',
+                        headers: {
+                            host: 'example.com',
+                            authorization: Oz.client.header('http://example.com/oz/rsvp', 'POST', reAppTicket).field
+                        }
+                    };
+
+                    Oz.endpoints.rsvp(req, payload, options, (err, ticket) => {
+
+                        expect(err).to.not.exist();
+
+                        // The app requests an rsvp to delegate the ticket to another app
+
+                        payload = {
+                            delegateTo: apps.network.id,
+                            scope: ['a']
+                        };
+
+                        req = {
+                            method: 'POST',
+                            url: '/oz/delegate',
+                            headers: {
+                                host: 'example.com',
+                                authorization: Oz.client.header('http://example.com/oz/delegate', 'POST', ticket).field
+                            }
+                        };
+
+                        Oz.endpoints.delegate(req, payload, options, (err, delegate) => {
+
+                            expect(err).to.not.exist();
+
+                            // The other app requests an app ticket
+
+                            req = {
+                                method: 'POST',
+                                url: '/oz/app',
+                                headers: {
+                                    host: 'example.com',
+                                    authorization: Oz.client.header('http://example.com/oz/app', 'POST', apps.network).field
+                                }
+                            };
+
+                            Oz.endpoints.app(req, null, options, (err, otherAppTicket) => {
+
+                                expect(err).to.not.exist();
+
+                                // The other app exchanges the rsvp for a delegated user ticket
+
+                                payload = { rsvp: delegate.rsvp };
+
+                                req = {
+                                    method: 'POST',
+                                    url: '/oz/rsvp',
+                                    headers: {
+                                        host: 'example.com',
+                                        authorization: Oz.client.header('http://example.com/oz/rsvp', 'POST', otherAppTicket).field
+                                    }
+                                };
+
+                                Oz.endpoints.rsvp(req, payload, options, (err, delegatedTicket) => {
+
+                                    expect(err).to.not.exist();
+                                    done();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
 });
-
-

--- a/test/ticket.js
+++ b/test/ticket.js
@@ -492,6 +492,19 @@ describe('Ticket', () => {
         });
     });
 
+    describe('delegateRsvp()', () => {
+
+        it('errors on invalid delegating app', (done) => {
+
+            Oz.ticket.delegateRsvp({ id: '123' }, null, null, null, password, {}, (err, rsvp) => {
+
+                expect(err).to.exist();
+                expect(err.message).to.equal('Invalid delegating application object');
+                done();
+            });
+        });
+    });
+
     describe('generate()', () => {
 
         it('errors on random fail', (done) => {
@@ -609,5 +622,3 @@ describe('Ticket', () => {
         });
     });
 });
-
-


### PR DESCRIPTION
I've made an attempt to implement the workflow I proposed in #47.

There's a new 'delegate' endpoint that will return an rsvp code encapsulating the user grant identifier, the two application identifiers and optionally a subset of scopes to delegate. The receiving app can exchange the rsvp for a delegated user ticket using the existing rsvp-endpoint.

Because an rsvp always encapsulates a user grant, it is not possible to delegate app tickets with this workflow (this is possible using the reissue-endpoint, although I can't think of a use case for it).

So if this is considered to be merged -- what happens with the old delegation workflow? Should I keep it for compatibility reasons? I think there should at least be a way to disable it.

For now, I left all existing functionality intact.
